### PR TITLE
Fix metadata for SLES15SP3

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -25,6 +25,7 @@
  */
 @Library('csm-shared-library')
 
+def sleVersion = '15.3'
 def isStable = env.TAG_NAME != null || env.BRANCH_NAME == 'main' ? true : false
 pipeline {
     agent {
@@ -33,6 +34,8 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: "10"))
+        disableConcurrentBuilds()
+        timeout(time: 20, unit: 'MINUTES')
         timestamps()
     }
 
@@ -47,11 +50,18 @@ pipeline {
     }
 
     stages {
-        stage("Prepare") {
-             steps {
-             runLibraryScript("addRpmMetaData.sh", env.SPEC_FILE)
-             sh "make prepare"
-           }
+        stage("Prepare: RPM") {
+            agent {
+                docker {
+                    label 'docker'
+                    reuseNode true
+                    image "artifactory.algol60.net/csm-docker/stable/csm-docker-sle:${sleVersion}"
+                }
+            }
+            steps {
+                runLibraryScript("addRpmMetaData.sh", "${env.GIT_REPO_NAME}.spec")
+                sh "make prepare"
+            }
         }
 
         stage("Build: RPM") {
@@ -59,8 +69,7 @@ pipeline {
                 docker {
                     label 'docker'
                     reuseNode true
-                    image "artifactory.algol60.net/csm-docker/stable/csm-docker-sle:15.3"
-                    args "-v ${env.WORKSPACE}:/workspace"
+                    image "artifactory.algol60.net/csm-docker/stable/csm-docker-sle:${sleVersion}"
                 }
             }
             steps {


### PR DESCRIPTION
Right now pit-nexus is missing git information from its package description and a value for its distribution:
```
Name        : pit-nexus
Version     : 1.1.4
Release     : 1
Architecture: x86_64
Install Date: Tue 10 May 2022 07:52:05 PM UTC
Group       : Unspecified
Size        : 1540992472
License     : MIT
Signature   : (none)
Source RPM  : pit-nexus-1.1.4-1.src.rpm
Build Date  : Mon 09 May 2022 10:30:30 PM UTC
Build Host  : 653361cedca6
Relocations : (not relocatable)
Vendor      : Hewlett Packard Enterprise Development LP
Summary     : Daemon for running Nexus repository manager
Description :
This RPM installs the daemon file for Nexus, launched through podman. This allows nexus to launch
as a systemd service on a system.
Distribution: (none)
```

This amends git information to the description while setting a value for distribution:
```
Description :
Git Repository: pit-nexus
Git Branch: metadata
Git Commit Revision: 3809583c
Git Commit Timestamp: Fri May 20 17:03:11 2022 -0500

This RPM installs the daemon file for Nexus, launched through podman. This allows nexus to launch
as a systemd service on a system.
Distribution: SUSE Linux Enterprise Server 15 SP3
```