### PR TITLE
Publish RPMs to both dropoff locations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 # See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners
 
 *       @Cray-HPE/platform-engineering
+*       @Cray-HPE/metal

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -80,7 +80,8 @@ pipeline {
         stage('Publish: RPM') {
             steps {
                 script {
-                    publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "build/RPMS/x86_64/*.rpm", arch: "x86_64", isStable: isStable)
+                    publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "build/RPMS/x86_64/*.rpm", os: "sle-15sp2", arch: "x86_64", isStable: isStable)
+                    publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "build/RPMS/x86_64/*.rpm", os: "sle-15sp3", arch: "x86_64", isStable: isStable)
                 }
             }
         }


### PR DESCRIPTION
This just publishes RPMs to both locations:
- https://artifactory.algol60.net/ui/repos/tree/General/csm-rpms/sle-15sp2/
- https://artifactory.algol60.net/ui/repos/tree/General/csm-rpms/sle-15sp3/

Since the package is compatible with both distros, this removes the opportunity for any misconception while allowing zypper to pull the latest RPM all the same.