### PR TITLE
CASMTRIAGE-3697: Add docker tags to skopeo copy

### DIFF
--- a/pit-nexus.spec
+++ b/pit-nexus.spec
@@ -65,7 +65,7 @@ sed -e 's,@@cray-nexus-setup-image@@,%{cray_nexus_setup_image},g' \
 # Consider switching to skopeo copy --all docker://<src> oci-archive:<dest>
 skopeo --override-arch amd64 --override-os linux copy docker://%{sonatype_nexus3_image}  docker-archive:%{sonatype_nexus3_file}
 skopeo --override-arch amd64 --override-os linux copy docker://%{cray_nexus_setup_image} docker-archive:%{cray_nexus_setup_file}
-skopeo --override-arch amd64 --override-os linux copy docker://%{skopeo_image}           docker-archive:%{skopeo_file}
+skopeo --override-arch amd64 --override-os linux copy docker://%{skopeo_image}           docker-archive:%{skopeo_file}:%{skopeo_image}:%{skopeo_tag}
 
 %install
 install -D -m 0644 -t %{buildroot}%{_unitdir} nexus.service


### PR DESCRIPTION
Newer podman load doesn't accept arguments anymore, so we either need to
update ansible plays to tag images loaded from this skopeo copy or have
skopeo copy save the information in the tarball.

For simplicities sake, the latter is being chosen here. The goal is to
ensure that the docker-archive tarball has the following in
manifest.json when built via:
skopeo copy source dest:some/tag:version
[{"Config":"e5a6560ada4411ca57bdc55c584e5370a9c96374d75c7568bda3f9b321427295.json","RepoTags":["quay.io/skopeo/stable:latest"],"Layers":rest
omitted

Versus if we do
skopeo copy source dest (note missing some/tag:version)
[{"Config":"e5a6560ada4411ca57bdc55c584e5370a9c96374d75c7568bda3f9b321427295.json","RepoTags":[],"Layers":rest

With RepoTags set to the repo:tagversion podman load loads as expected
(sans the final arg to podman load).

### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3697
- Requires:
- Relates to:

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request


<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ x] I have included documentation in my PR (or it is not required)
- [ x] I tested this on internal system On sorter where this was observed, manually updated manifest.json in the tarball provided by this rpm and validated podman load worked manually to work around the issue. This pr however needs to be present before the ansible changes can work.
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
No risks really for this, the only change is to that RepoTags key ultimately.
