### PR TITLE
Update nexus3 and cray-nexus-setup versions

### DIFF
--- a/pit-nexus.spec
+++ b/pit-nexus.spec
@@ -23,11 +23,11 @@ Requires: podman-cni-config
 %define imagedir %{_sharedstatedir}/cray/container-images/%{name}
 
 %define current_branch %(echo ${GIT_BRANCH} | sed -e 's,/.*$,,')
-%define sonatype_nexus3_tag   3.25.0-2
+%define sonatype_nexus3_tag   3.37.0
 %define sonatype_nexus3_image artifactory.algol60.net/csm-docker/stable/nexus3:%{sonatype_nexus3_tag}
 %define sonatype_nexus3_file  sonatype-nexus3-%{sonatype_nexus3_tag}.tar
 
-%define cray_nexus_setup_tag   0.5.2
+%define cray_nexus_setup_tag   0.7.1
 %define cray_nexus_setup_image artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:%{cray_nexus_setup_tag}
 %define cray_nexus_setup_file  cray-nexus-setup-%{cray_nexus_setup_tag}.tar
 


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

Updates nexus and cray-nexus setup to more recent versions.  This version seems to work better in vshasta, and we haven't updated it for 6-12 months.

- Fixes: VSHA-505
- Relates to: CASMTRIAGE-4360, VSHA-502, VSHA-503, [#169](https://github.com/Cray-HPE/livecd-gcp-infrastructure/pull/169)

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describeT what this change is and what it is for. -->

Seems to help prevent the occurrence of these intermittent issues seen on vshasta.

```
Oct 25 19:16:57 pit nexus-init.sh[28820]: Copying blob sha256:56600e1ac4c8170f1591ee9a6ee10ae5ace2eff5dff939181d83d8ecb76646ed
Oct 25 19:16:57 pit nexus-init.sh[28820]: Copying config sha256:7d6a2be1d717b5c87ecbe1aa893f6366e5b9f0ac464785fb90f2025f8ce96fdd
Oct 25 19:16:57 pit nexus-init.sh[28820]: Writing manifest to image destination
Oct 25 19:16:57 pit nexus-init.sh[28820]: Storing signatures
Oct 25 19:16:58 pit nexus-init.sh[28820]: Loaded image(s): sha256:7d6a2be1d717b5c87ecbe1aa893f6366e5b9f0ac464785fb90f2025f8ce96fdd
Oct 25 19:16:58 pit podman[28820]: 2022-10-25 19:16:57.203162816 +0000 UTC m=+0.043110803 image loadfromarchive  /var/lib/cray/container-image>
Oct 25 19:16:58 pit podman[28911]: 2022-10-25 19:16:58.327925035 +0000 UTC m=+0.047338303 image tag 7d6a2be1d717b5c87ecbe1aa893f6366e5b9f0ac46>
Oct 25 19:16:58 pit nexus-init.sh[28953]: Error: readlink /var/lib/containers/storage/overlay: invalid argument
Oct 25 19:16:58 pit systemd[1]: nexus.service: Control process exited, code=exited, status=125/n/a
```

and

```
Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: No content to map due to end-of-input
 at [Source: (File); line: 1, column: 0]
	at com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:59)
	at com.fasterxml.jackson.databind.ObjectMapper._initForReading(ObjectMapper.java:4146)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4001)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2922)
	at org.sonatype.nexus.orient.internal.freeze.LocalDatabaseFrozenStateManager.readMarkerFile(LocalDatabaseFrozenStateManager.java:122)
	... 13 common frames omitted
2022-10-13 15:36:29,808+0000 INFO  [FelixStartLevel] *SYSTEM org.sonatype.nexus.extender.NexusContextListener - Uptime: 22 seconds and 725 milliseconds (nexus-oss-edition/3.25.0.03)
2022-10-13 15:36:29,809+0000 INFO  [FelixStartLevel] *SYSTEM org.sonatype.nexus.extender.NexusLifecycleManager - Shutting down
2022-10-13 15:36:29,810+0000 INFO  [FelixStartLevel] *SYSTEM org.sonatype.nexus.extender.NexusLifecycleManager - Stop KERNEL
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [x] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->

Medium.  This solves some issues, but new stuff can always bring the unknown.