### PR TITLE
MTL-1708 Build & Publish SP4 RPMs

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -27,7 +27,6 @@
 
 def isStable = env.TAG_NAME != null ? true : false
 def sleImage = 'artifactory.algol60.net/csm-docker/stable/csm-docker-sle'
-def sleVersion = '15.3'
 pipeline {
 
     agent {
@@ -44,44 +43,83 @@ pipeline {
     environment {
         DOCKER_ARGS = getDockerBuildArgs(name: getRepoName(), description: 'A podman image for nexus')
         NAME = getRepoName()
+        IS_STABLE = "${isStable}"
         VERSION = sh(returnStdout: true, script: "git describe --tags | tr -s '-' '_' | tr -d '^v'").trim()
     }
 
     stages {
 
-        stage('Prepare: RPMs') {
-            agent {
-                docker {
-                    label 'docker'
-                    reuseNode true
-                    image "${sleImage}:${sleVersion}"
-                }
-            }
-            steps {
-                runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
-                sh "make prepare"
-                sh "git update-index --assume-unchanged ${env.NAME}.spec"
-            }
-        }
+        stage('Build & Publish') {
 
-        stage('Build: RPMs') {
-            agent {
-                docker {
-                    label 'docker'
-                    reuseNode true
-                    image "${sleImage}:${sleVersion}"
-                }
-            }
-            steps {
-                sh "make rpm"
-            }
-        }
+            matrix {
 
-        stage('Publish: RPMs') {
-            steps {
-                script {
-                    publishCsmRpms(component: env.NAME, pattern: "build/RPMS/x86_64/*.rpm", os: "sle-15sp2", arch: "x86_64", isStable: isStable)
-                    publishCsmRpms(component: env.NAME, pattern: "build/RPMS/x86_64/*.rpm", os: "sle-15sp3", arch: "x86_64", isStable: isStable)
+                agent {
+                    node {
+                        label "metal-gcp-builder"
+                        customWorkspace "${env.WORKSPACE}/${sleVersion}"
+                    }
+                }
+
+                axes {
+                    axis {
+                        name 'sleVersion'
+                        values 15.3, 15.4
+                    }
+                }
+
+                stages {
+
+                    stage('Prepare: RPMs') {
+                        agent {
+                            docker {
+                                label 'docker'
+                                reuseNode true
+                                image "${sleImage}:${sleVersion}"
+                            }
+                        }
+                        steps {
+                            runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
+                            sh "make prepare"
+                            sh "git update-index --assume-unchanged ${env.NAME}.spec"
+                        }
+                    }
+
+                    stage('Build: RPMs') {
+                        agent {
+                            docker {
+                                label 'docker'
+                                reuseNode true
+                                image "${sleImage}:${sleVersion}"
+                            }
+                        }
+                        steps {
+                            sh "make rpm"
+                        }
+                    }
+
+                    stage('Publish: RPMs') {
+                        steps {
+                            script {
+                                sles_version_parts = "${sleVersion}".tokenize('.')
+                                sles_major = "${sles_version_parts[0]}"
+                                sles_minor = "${sles_version_parts[1]}"
+                                publishCsmRpms(
+                                        arch: "x86_64", 
+                                        component: env.NAME, 
+                                        isStable: isStable,
+                                        os: "sle-${sles_major}sp${sles_minor}", 
+                                        pattern: "build/RPMS/x86_64/*.rpm",
+                                )
+                                publishCsmRpms(
+                                        arch: "src", 
+                                        component: env.NAME, 
+                                        isStable: isStable,
+                                        os: "sle-${sles_major}sp${sles_minor}", 
+                                        pattern: "build/SRPMS/*.rpm",
+                                )
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-1708

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Continue to build and publish SP3 RPMs while publishing SP4 RPMs. Include the correct, respective metadata in each RPM.

The SLES 15SP3 build creates an RPM with SP3 metadata and publishes it to `sle-15sp3`:

```bash
Name        : pit-nexus
Version     : 1.2.0_2_gea43bbe
Release     : 1
Architecture: x86_64
Install Date: (not installed)
Group       : Unspecified
Size        : 1035512788
License     : MIT
Signature   : (none)
Source RPM  : pit-nexus-1.2.0_2_gea43bbe-1.src.rpm
Build Date  : Wed Nov 23 23:32:45 2022
Build Host  : 655fae1f66ce
Relocations : (not relocatable)
Vendor      : Hewlett Packard Enterprise Development LP
URL         : https://github.com/Cray-HPE/pit-nexus.git
Summary     : Daemon for running Nexus repository manager
Description :
Git Repository: pit-nexus
Git Branch: MTL-1708-SP4
Git Commit Revision: ea43bbe3
Git Commit Timestamp: Wed Nov 23 17:29:51 2022 -0600

This RPM installs the daemon file for Nexus, launched through podman. This allows nexus to launch
as a systemd service on a system.
Distribution: SUSE Linux Enterprise Server 15 SP3
```

The SLES 15SP4 build creates an RPM with SP4 metadata, and publishes it to `sle-15sp4`:

```bash
Name        : pit-nexus
Version     : 1.2.0_2_gea43bbe
Release     : 1
Architecture: x86_64
Install Date: (not installed)
Group       : Unspecified
Size        : 1035512788
License     : MIT
Signature   : (none)
Source RPM  : pit-nexus-1.2.0_2_gea43bbe-1.src.rpm
Build Date  : Wed Nov 23 23:32:46 2022
Build Host  : b8aa04b8fcb7
Relocations : (not relocatable)
Packager    : https://www.suse.com/
Vendor      : Hewlett Packard Enterprise Development LP
URL         : https://github.com/Cray-HPE/pit-nexus.git
Summary     : Daemon for running Nexus repository manager
Description :
Git Repository: pit-nexus
Git Branch: MTL-1708-SP4
Git Commit Revision: ea43bbe3
Git Commit Timestamp: Wed Nov 23 17:29:51 2022 -0600

This RPM installs the daemon file for Nexus, launched through podman. This allows nexus to launch
as a systemd service on a system.
Distribution: SUSE Linux Enterprise Server 15 SP4
```
### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
