### PR TITLE
MTL-2171

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),
@@ -44,7 +44,8 @@ pipeline {
         DOCKER_ARGS = getDockerBuildArgs(name: getRepoName(), description: 'A podman image for nexus')
         NAME = getRepoName()
         IS_STABLE = "${isStable}"
-        VERSION = sh(returnStdout: true, script: "git describe --tags | tr -s '-' '_' | tr -d '^v'").trim()
+        PRIMARY_NODE = "${env.NODE_NAME}"
+        VERSION = sh(returnStdout: true, script: "git describe --tags | tr -s '-' '~' | sed 's/^v//'").trim()
     }
 
     stages {
@@ -53,30 +54,40 @@ pipeline {
 
             matrix {
 
-                agent {
-                    node {
-                        label "metal-gcp-builder"
-                        customWorkspace "${env.WORKSPACE}/${sleVersion}"
-                    }
+                environment {
+                    DOCKER_ARCH = sh(returnStdout: true, script: "[ ${ARCH} == 'x86_64' ] && echo -n 'amd64' || echo -n 'arm64'")
+                    BUILD_DIR = "${env.WORKSPACE}/dist/rpmbuild/${ARCH}"
                 }
 
                 axes {
+
                     axis {
-                        name 'sleVersion'
-                        values 15.3, 15.4
+                        name 'ARCH'
+                        values 'x86_64'
                     }
                 }
 
                 stages {
 
+                    stage('Build: setup') {
+                        steps {
+                            lock('docker-image-pull') {
+                                sh "docker pull --platform linux/${DOCKER_ARCH} ${sleImage}"
+                                sh "docker tag ${sleImage} ${sleImage}:${DOCKER_ARCH}"
+                            }
+                        }
+                    }
+
                     stage('Prepare: RPMs') {
                         agent {
                             docker {
-                                label 'docker'
+                                label "${PRIMARY_NODE}"
                                 reuseNode true
-                                image "${sleImage}:${sleVersion}"
+                                args "-v /home/jenkins/.ssh:/home/jenkins/.ssh --platform linux/${DOCKER_ARCH}"
+                                image "${sleImage}:${DOCKER_ARCH}"
                             }
                         }
+
                         steps {
                             runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
                             sh "make prepare"
@@ -87,35 +98,71 @@ pipeline {
                     stage('Build: RPMs') {
                         agent {
                             docker {
-                                label 'docker'
+                                label "${PRIMARY_NODE}"
                                 reuseNode true
-                                image "${sleImage}:${sleVersion}"
+                                args "-v /home/jenkins/.ssh:/home/jenkins/.ssh --platform linux/${DOCKER_ARCH}"
+                                image "${sleImage}:${DOCKER_ARCH}"
                             }
                         }
+
                         steps {
-                            sh "make rpm"
+                            withCredentials([
+                                    usernamePassword(
+                                            credentialsId: 'artifactory-algol60-readonly',
+                                            usernameVariable: 'ARTIFACTORY_USER',
+                                            passwordVariable: 'ARTIFACTORY_TOKEN'
+                                    )
+                            ]) {
+                                script {
+                                    sh "make rpm"
+                                }
+                            }
                         }
                     }
 
                     stage('Publish: RPMs') {
+                        agent {
+                            docker {
+                                label "${PRIMARY_NODE}"
+                                reuseNode true
+                                args "-v /home/jenkins/.ssh:/home/jenkins/.ssh --platform linux/${DOCKER_ARCH}"
+                                image "${sleImage}:${DOCKER_ARCH}"
+                            }
+                        }
+
                         steps {
                             script {
+                                def sleVersion = sh(returnStdout: true, script: 'awk -F= \'/VERSION_ID/{gsub(/["]/,""); print \$NF}\' /etc/os-release').trim()
                                 def sles_version_parts = "${sleVersion}".tokenize('.')
                                 def sles_major = "${sles_version_parts[0]}"
                                 def sles_minor = "${sles_version_parts[1]}"
                                 publishCsmRpms(
-                                        arch: "x86_64", 
-                                        component: env.NAME, 
+                                        arch: "${ARCH}",
+                                        component: env.NAME,
                                         isStable: isStable,
-                                        os: "sle-${sles_major}sp${sles_minor}", 
-                                        pattern: "build/RPMS/x86_64/*.rpm",
+                                        os: "sle-${sles_major}sp${sles_minor}",
+                                        pattern: "dist/rpmbuild/${ARCH}/RPMS/${ARCH}/*.rpm",
                                 )
                                 publishCsmRpms(
-                                        arch: "src", 
-                                        component: env.NAME, 
+                                        arch: "src",
+                                        component: env.NAME,
                                         isStable: isStable,
-                                        os: "sle-${sles_major}sp${sles_minor}", 
-                                        pattern: "build/SRPMS/*.rpm",
+                                        os: "sle-${sles_major}sp${sles_minor}",
+                                        pattern: "dist/rpmbuild/${ARCH}/SRPMS/*.rpm",
+                                )
+                                publishCsmRpms(
+                                        arch: "${ARCH}",
+                                        component: env.NAME,
+                                        isStable: isStable,
+                                        os: "noos",
+                                        pattern: "dist/rpmbuild/${ARCH}/RPMS/${ARCH}/*.rpm",
+                                )
+                                publishCsmRpms(
+                                        arch: "src",
+                                        component: env.NAME,
+                                        isStable: isStable,
+                                        os: "noos",
+                                        pattern: "dist/rpmbuild/${ARCH}/SRPMS/*.rpm",
                                 )
                             }
                         }

--- a/pit-nexus.spec
+++ b/pit-nexus.spec
@@ -84,8 +84,8 @@ sed -e 's,@@cray-nexus-setup-image@@,%{cray_nexus_setup_image},g' \
     -e 's,@@cray-nexus-setup-path@@,%{imagedir}/%{cray_nexus_setup_file},g' \
     %{SOURCE3} > nexus-setup.sh
 # Consider switching to skopeo copy --all docker://<src> oci-archive:<dest>
-skopeo --override-arch amd64 --override-os linux copy docker://%{sonatype_nexus3_image}  docker-archive:%{sonatype_nexus3_file}
-skopeo --override-arch amd64 --override-os linux copy docker://%{cray_nexus_setup_image} docker-archive:%{cray_nexus_setup_file}
+skopeo --override-arch amd64 --override-os linux copy --src-creds=%(echo $ARTIFACTORY_USER:$ARTIFACTORY_TOKEN) docker://%{sonatype_nexus3_image}  docker-archive:%{sonatype_nexus3_file}
+skopeo --override-arch amd64 --override-os linux copy --src-creds=%(echo $ARTIFACTORY_USER:$ARTIFACTORY_TOKEN) docker://%{cray_nexus_setup_image} docker-archive:%{cray_nexus_setup_file}
 skopeo --override-arch amd64 --override-os linux copy docker://%{skopeo_image}           docker-archive:%{skopeo_file}:%{skopeo_image}:%{skopeo_tag}
 
 %install


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2171

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Enables pulling images from artifactory.algol60.net with credentials.

Additional changes:
- Publish to `noos`, cease publishing to `15.3`
- Use less builders; spin docker containers up on single host
- Publishes a `src` RPM

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
