### PR TITLE
Set sub-path

### DIFF
--- a/systemd/nexus-init.sh
+++ b/systemd/nexus-init.sh
@@ -57,6 +57,7 @@ if ! podman volume inspect "$NEXUS_VOLUME_NAME" &>/dev/null; then
         "$NEXUS_IMAGE" /bin/sh -c "
 mkdir -p /nexus-data/etc
 cat > /nexus-data/etc/nexus.properties << EOF
+nexus-context-path=/nexus
 nexus.onboarding.enabled=false
 nexus.scripts.allowCreation=true
 nexus.security.randompassword=false

--- a/systemd/nexus-setup.sh
+++ b/systemd/nexus-setup.sh
@@ -79,6 +79,7 @@ fi
 podman run --rm --network host \
     "$NEXUS_SETUP_IMAGE" \
     /bin/sh -c "
+export NEXUS_URL=http://localhost:8081/nexus
 while ! nexus-ready; do
   echo >&2 'Waiting for nexus to be ready, trying again in 10 seconds'
   sleep 10


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: https://github.com/Cray-HPE/metal-provision/pull/434

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
In some cases we serve this nexus instance at a `/nexus` sub-path.

In order for the URLs to be correct in Nexus' dashboard, e.g. repository URLs, nexus needs to be aware of the sub-path.

The address bar had `http://redbull-ncn-m001.hpc.amslabs.hpecorp.net/nexus/#admin/repository/repositories:cray-algol60-csm-rpms-stable-noos`, but the repository URL value did not include the `/nexus` sub-path:
![image](https://github.com/Cray-HPE/metal-nexus/assets/7772179/d3cea84a-4271-480c-ab03-63154cfc4f42)

Now observe that the address bar and the repository URL are aligned:
![Screenshot 2023-09-05 at 20 59 43](https://github.com/Cray-HPE/metal-nexus/assets/7772179/897a58e6-273a-475d-8c81-f69b04978f8f)

For this to work, the healthcheck also needs to validate the subpath.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
