### PR TITLE
Cease and desist destructive tendencies

### DIFF
--- a/systemd/nexus-setup.sh
+++ b/systemd/nexus-setup.sh
@@ -89,26 +89,5 @@ done
 nexus-upload-script /usr/local/share/nexus-setup/groovy/*.groovy >&2
 
 nexus-enable-anonymous-access >&2
-nexus-remove-default-repos >&2
-
-cat > /tmp/nexus-repositories.yaml << EOF
----
-cleanup: null
-docker:
-  forceBasicAuth: false
-  httpPort: 5000
-  httpsPort: null
-  v1Enabled: false
-format: docker
-name: registry
-online: true
-storage:
-  blobStoreName: default
-  strictContentTypeValidation: false
-  writePolicy: ALLOW
-${config}
-EOF
-
-nexus-repositories-create /tmp/nexus-repositories.yaml >&2
 nexus-enable-docker-realm >&2
 " || exit


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: https://github.com/Cray-HPE/metal-provision/pull/550

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
I'm hitting a problem when restarting nexus, where the `registry` suddenly changes blobstore and repos vanish.

The problem is that `nexus-setup.sh` runs as an `ExecPostStart` script on the systemd service, and when it runs it has two destructive options.

These destructive options make it impossible to restart the nexus service without harming an existing registry. For example, in Fawkes we create a registry in the fawkes blobstore. Restarting nexus causes that registry to be recreated again under the default blobstore, this ends up breaking image pulls.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
