### PR TITLE
CASM-4669 Upgrade Nexus to 3.67.1 to support image signatures

### DIFF
--- a/systemd/nexus-init.sh
+++ b/systemd/nexus-init.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2022,2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -43,14 +43,9 @@ NEXUS_VOLUME_MOUNT="/nexus-data:rw,exec"
 
 # Create Nexus volume if not already present
 if ! podman volume inspect "$NEXUS_VOLUME_NAME" &>/dev/null; then
-    # Load busybox image if it doesn't already exist
+    # Load nexus image if it doesn't already exist
     if ! podman image inspect "$NEXUS_IMAGE" &>/dev/null; then
-        # load the image
         podman load -i "$NEXUS_IMAGE_PATH" || exit
-        # get the tag
-        NEXUS_IMAGE_ID=$(podman images --noheading --format "{{.Id}}" --filter label="name=Nexus Repository Manager")
-        # tag the image
-        podman tag "$NEXUS_IMAGE_ID" "$NEXUS_IMAGE"
     fi
     podman run --rm --network host \
         -v "${NEXUS_VOLUME_NAME}:${NEXUS_VOLUME_MOUNT}" \
@@ -76,12 +71,7 @@ if ! podman inspect --type container "$NEXUS_CONTAINER_NAME" &>/dev/null; then
     rm -f "$NEXUS_CIDFILE" || exit
     # Load nexus image if it doesn't already exist
     if ! podman image inspect "$NEXUS_IMAGE" &>/dev/null; then
-        # load the image
         podman load -i "$NEXUS_IMAGE_PATH"
-        # get the tag
-        NEXUS_IMAGE_ID=$(podman images --noheading --format "{{.Id}}" --filter label="name=Nexus Repository Manager")
-        # tag the image
-        podman tag "$NEXUS_IMAGE_ID" "$NEXUS_IMAGE"
     fi
     podman create \
         --conmon-pidfile "$NEXUS_PIDFILE" \

--- a/systemd/nexus-setup.sh
+++ b/systemd/nexus-setup.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2022,2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -67,12 +67,7 @@ fi
 set -x
 
 if ! podman image inspect --type image "$NEXUS_SETUP_IMAGE" &>/dev/null; then
-    # load the image
     podman load -i "$NEXUS_SETUP_IMAGE_PATH" || exit
-    # get the image id
-    CRAY_NEXUS_SETUP_ID=$(podman images --noheading --format "{{.Id}}" --filter label="org.label-schema.name=cray-nexus-setup")
-    # tag the image
-    podman tag "$CRAY_NEXUS_SETUP_ID" "$NEXUS_SETUP_IMAGE"
 fi
 
 # Setup Nexus container (assumes Nexus is at http://localhost:8081)


### PR DESCRIPTION
### Summary and Scope

To support multi-platform container image uploads together with Sigstore attachments, we need to upgrade metal nexus to latest version 3.67.1. This also involves upgrade of `cray-nexus-setup` to 0.11.0.

#### Issue Type

- Bugfix Pull Request
- RFE Pull Request

### Prerequisites
- [x] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [x] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Testing
* Ran a few iterations of install/upgrade/uninstall RPM package on vShasta PIT node. Ensured that upgraded Nexus service starts up properly.
* Ran `/srv/cray/metal-provision/scripts/nexus/setup-nexus.sh` script to initialize repositories and pour new content in Nexus
* Ensured that newly uploaded images have all required components - versions for multiple platforms and sigstore attachments: 
![image](https://github.com/Cray-HPE/metal-nexus/assets/320082/c7a63633-964e-4cfd-a736-d8e71c0f915c)
On the screenshot above, more then 1 manifest per tag denotes multi-platform images (aka "manifest lists"), and tag named `sha256-*.sig` denotes Sigstore attachment.

### Idempotency
For better idempotency, fixed couple of bugs related to package upgrade flow:
* RPM package install does not fail anymore if nexus or cray-nexus-setup images are already loaded into podman
* Fixed cleanup in RPM package post-install script to remove nexus and cray-nexus-setup images properly
 
### Risks and Mitigations
 
This introduces some risk since this change also brings in a newer version of Nexus, but otherwise a new functionality required by CSM 1.6 roadmap can not be achieved.
