### PR TITLE
CASMPET-7068 Upgrade Nexus to 3.68.1

### DIFF
--- a/metal-nexus.spec
+++ b/metal-nexus.spec
@@ -26,7 +26,7 @@ License: MIT
 Summary: Daemon for running Nexus repository manager
 BuildArch: x86_64
 Version: %(echo $VERSION)
-Release: 3.67.1_1
+Release: 3.68.1_1
 Source1: nexus.service
 Source2: nexus-init.sh
 Source3: nexus-setup.sh


### PR DESCRIPTION
## Summary and Scope

Need to upgrade Nexus to 3.68.1 - vulnerability reported for versions up to 3.68.0: https://support.sonatype.com/hc/en-us/articles/29416509323923-CVE-2024-4956-Nexus-Repository-3-Path-Traversal-2024-05-16?_ga=2.111591940.162078004.1716391739-1182997560.1716391642

## Issues and Related PRs

* Resolves [CASMPET-7068](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7068)

## Risks and Mitigations

Low - 1.6 only, will rollback if any issues occur.