### PR TITLE
Increase RPM build timeout

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -36,7 +36,7 @@ pipeline {
     options {
         buildDiscarder(logRotator(numToKeepStr: "10"))
         disableConcurrentBuilds()
-        timeout(time: 20, unit: 'MINUTES')
+        timeout(time: 30, unit: 'MINUTES')
         timestamps()
     }
 


### PR DESCRIPTION
The RPM build is timing out on signed builds (stable), likely due to its increasing size.

Bump the timeout by 10 minutes.
